### PR TITLE
Plan `active` attribute type

### DIFF
--- a/database/seeds/VoyagerPlansDataRowsSeeder.php
+++ b/database/seeds/VoyagerPlansDataRowsSeeder.php
@@ -135,7 +135,7 @@ class VoyagerPlansDataRowsSeeder extends Seeder
                 'data_type_id' => $dataType->id,
                 'field' => 'active',
             ], [
-                'type' => 'number',
+                'type' => 'checkbox',
                 'display_name' => 'Active',
                 'required' => true,
                 'browse' => false,


### PR DESCRIPTION
change Plan `active` attribute type from 'number' to 'checkbox' for Voyager